### PR TITLE
Fix EVALUATE statement parsing bug

### DIFF
--- a/src/cobol/koopa/cobol/grammar/Cobol.kg
+++ b/src/cobol/koopa/cobol/grammar/Cobol.kg
@@ -3248,10 +3248,7 @@ end
 
 
 def when =
-    ( WHEN (%not OTHER) object
-      (ALSO object)*
-    )+ 
-    nestedStatements
+    WHEN (%not OTHER) object (ALSO object)* [nestedStatements]
 end
 
 def whenOther =

--- a/src/cobol/koopa/cobol/grammar/CobolGrammar.java
+++ b/src/cobol/koopa/cobol/grammar/CobolGrammar.java
@@ -13877,22 +13877,20 @@ public class CobolGrammar extends CobolBaseGrammar {
         whenParser = future;
         future.setParser(
           sequence(
-            plus(
+            keyword("WHEN"),
+            not(
+              keyword("OTHER")
+            ),
+            object(),
+            star(
               sequence(
-                keyword("WHEN"),
-                not(
-                  keyword("OTHER")
-                ),
-                object(),
-                star(
-                  sequence(
-                    keyword("ALSO"),
-                    object()
-                  )
-                )
+                keyword("ALSO"),
+                object()
               )
             ),
-            nestedStatements()
+            optional(
+              nestedStatements()
+            )
           )
         );
       }

--- a/test/cobol/koopa/cobol/grammar/test/EvaluateStatement.stage
+++ b/test/cobol/koopa/cobol/grammar/test/EvaluateStatement.stage
@@ -58,9 +58,10 @@ target when;
 +[ WHEN TRUE ALSO ANY ALSO 42
         DISPLAY "Good." ]
 
-+[ WHEN ANY
-   WHEN TRUE ALSO ANY
-   WHEN TRUE ALSO ANY ALSO 42
+# WHEN clauses need not have any statements themselves.
++[ WHEN ANY ]
++[ WHEN TRUE ALSO ANY ]
++[ WHEN TRUE ALSO ANY ALSO 42
         DISPLAY "Good." ]
 
 +[ when equals "HELLO WORLD"  DISPLAY "achievement unlocked" ]
@@ -120,3 +121,11 @@ target evaluateStatement;
 +[ EVALUATE WRK-XN-00001-1 NUMERIC
    WHEN TRUE
         DISPLAY "OK" ]
+
++[ EVALUATE CODE
+   WHEN 1
+   WHEN 2
+        DISPLAY "OK"
+   WHEN -1
+   WHEN OTHER
+        DISPLAY "NOT OK" ]


### PR DESCRIPTION
Following would cause the parser to fail:

    EVALUATE CODE
        WHEN 999
        WHEN OTHER
             DISPLAY "ERROR"
    END-EVALUATE

We could not have an empty `WHEN` preceding a `WHEN OTHER`. But this is allowed.