### PR TITLE
Tweak integerLiteral

### DIFF
--- a/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessing.kg
+++ b/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessing.kg
@@ -90,7 +90,14 @@ end
 def integerLiteral =
     ( '+' ++ uintgr
     | '-' ++ uintgr
+    
     | uintgr
+      # We want to be sure this is not the start of a cobolWord.
+      # E.g. 404-NOT-FOUND
+      (++ ( %at %not ( '-' | '_' | (@WORD _)) 
+          | eof 
+          )
+      )
     )
 end
 

--- a/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessing.properties
+++ b/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessing.properties
@@ -4,3 +4,4 @@ import.CobolPreprocessingBaseGrammar = koopa.cobol.grammar.preprocessing
 
 static.NUMBER         = koopa.core.data.tags.SyntacticTag
 static.STRING         = koopa.core.data.tags.SyntacticTag
+static.WORD           = koopa.core.data.tags.SyntacticTag

--- a/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessingGrammar.java
+++ b/src/cobol/koopa/cobol/grammar/preprocessing/CobolPreprocessingGrammar.java
@@ -12,6 +12,7 @@ import static koopa.core.grammars.combinators.Scoped.Visibility.HIDING;
 import koopa.cobol.grammar.preprocessing.CobolPreprocessingBaseGrammar;
 import static koopa.core.data.tags.SyntacticTag.NUMBER;
 import static koopa.core.data.tags.SyntacticTag.STRING;
+import static koopa.core.data.tags.SyntacticTag.WORD;
 
 /**
  * <b>This is generated code.<b>
@@ -468,7 +469,26 @@ public class CobolPreprocessingGrammar extends CobolPreprocessingBaseGrammar {
                 uintgr()
               )
             ),
-            uintgr()
+            sequence(
+              uintgr(),
+              opt(NOSKIP,
+                choice(
+                  at(
+                    not(
+                      choice(
+                        literal("-"),
+                        literal("_"),
+                        sequence(
+                          tagged(WORD),
+                          any()
+                        )
+                      )
+                    )
+                  ),
+                  eof()
+                )
+              )
+            )
           )
         );
       }

--- a/test/cobol/koopa/cobol/grammar/test/Basic.stage
+++ b/test/cobol/koopa/cobol/grammar/test/Basic.stage
@@ -39,6 +39,7 @@ target cobolWord;
 
 # But I'm disallowing numbers as legal cobol words for now.
 -[ 00 ]
+-integerLiteral
 
 
 # Names which start with a verb, followed by a number.
@@ -54,6 +55,10 @@ target integerLiteral;
 
 +[ 0 ]
 +[ 1 ]
+
++[ 404 ]
+-[ 404-NOT-FOUND ]
+-[ 404NOTFOUND ]
 
 -decimal
 -alphanumericLiteral


### PR DESCRIPTION
In places where both a number or a data name are allowed, names which start with a number could be mismatched and cause parse failure.