### PR TITLE
Issue #32: infinite recursion when calculating keywords

### DIFF
--- a/src/core/koopa/core/grammars/combinators/Dispatched.java
+++ b/src/core/koopa/core/grammars/combinators/Dispatched.java
@@ -52,13 +52,13 @@ public class Dispatched extends WithKeyword {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (ParserCombinator parser : lookupTable.values())
-			parser.addAllKeywordsInScopeTo(keywords);
+			parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (String key : lookupTable.keySet())
 			keywords.add(key);
 	}

--- a/src/core/koopa/core/grammars/combinators/MatchKeyword.java
+++ b/src/core/koopa/core/grammars/combinators/MatchKeyword.java
@@ -23,12 +23,12 @@ public class MatchKeyword extends TestProgramText {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(word);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(word);
 	}
 	

--- a/src/core/koopa/core/grammars/combinators/MatchNumber.java
+++ b/src/core/koopa/core/grammars/combinators/MatchNumber.java
@@ -57,12 +57,12 @@ public class MatchNumber extends GrammaticalCombinator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(comparableText);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(comparableText);
 	}
 	

--- a/src/core/koopa/core/grammars/combinators/MatchToken.java
+++ b/src/core/koopa/core/grammars/combinators/MatchToken.java
@@ -48,12 +48,12 @@ public class MatchToken extends GrammaticalCombinator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(comparableText);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		keywords.add(comparableText);
 	}
 

--- a/src/core/koopa/core/grammars/combinators/Scoped.java
+++ b/src/core/koopa/core/grammars/combinators/Scoped.java
@@ -169,15 +169,25 @@ public class Scoped extends FutureParser {
 	 * for the overall structure of the program, and little else.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
+		// No need to figure out all our keywords twice.
+		if (scopesSeen.contains(name))
+			return;
+		
+		scopesSeen.add(name);
 		if (allowKeywords)
-			parser.addAllLeadingKeywordsTo(keywords);
+			parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
+		// No need to figure out all our keywords twice.
+		if (scopesSeen.contains(name))
+			return;
+		
+		scopesSeen.add(name);
 		if (allowKeywords)
-			parser.addAllLeadingKeywordsTo(keywords);
+			parser.addAllLeadingKeywordsTo(keywords, scopesSeen);		
 	}
 
 	@Override

--- a/src/core/koopa/core/grammars/combinators/TestProgramText.java
+++ b/src/core/koopa/core/grammars/combinators/TestProgramText.java
@@ -74,13 +74,13 @@ public abstract class TestProgramText extends GrammaticalCombinator {
 			String programText);
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
-		parser.addAllKeywordsInScopeTo(keywords);
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
-		parser.addAllLeadingKeywordsTo(keywords);
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	@Override

--- a/src/core/koopa/core/grammars/combinators/WrappedAs.java
+++ b/src/core/koopa/core/grammars/combinators/WrappedAs.java
@@ -49,13 +49,13 @@ public class WrappedAs extends ParserCombinator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
-		parser.addAllKeywordsInScopeTo(keywords);
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
-		parser.addAllLeadingKeywordsTo(keywords);
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	@Override

--- a/src/core/koopa/core/parsers/FutureParser.java
+++ b/src/core/koopa/core/parsers/FutureParser.java
@@ -23,13 +23,13 @@ public class FutureParser extends ParserCombinator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
-		parser.addAllKeywordsInScopeTo(keywords);
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
-		parser.addAllLeadingKeywordsTo(keywords);
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	@Override
@@ -50,7 +50,7 @@ public class FutureParser extends ParserCombinator {
 	private Set<String> getAllKeywordsInScope() {
 		if (allKeywords == null) {
 			allKeywords = new HashSet<>();
-			parser.addAllKeywordsInScopeTo(allKeywords);
+			parser.addAllKeywordsInScopeTo(allKeywords, new HashSet<>());
 		}
 
 		return allKeywords;

--- a/src/core/koopa/core/parsers/Optimizer.java
+++ b/src/core/koopa/core/parsers/Optimizer.java
@@ -1,5 +1,6 @@
 package koopa.core.parsers;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -64,7 +65,7 @@ public class Optimizer {
 
 		for (ParserCombinator p : parsers) {
 			final Set<String> keywords = new LinkedHashSet<>();
-			p.addAllLeadingKeywordsTo(keywords);
+			p.addAllLeadingKeywordsTo(keywords, new HashSet<>());
 			for (String kw : keywords) {
 				if (!mapping.containsKey(kw))
 					mapping.put(kw, new LinkedList<ParserCombinator>());

--- a/src/core/koopa/core/parsers/ParserCombinator.java
+++ b/src/core/koopa/core/parsers/ParserCombinator.java
@@ -47,7 +47,7 @@ public abstract class ParserCombinator {
 	 * <p>
 	 * By default this leaves the set untouched.
 	 */
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
@@ -55,13 +55,13 @@ public abstract class ParserCombinator {
 	 * <p>
 	 * By default this leaves the set untouched.
 	 */
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
 	 * Can the leading keywords be used for lookahead ? That is, must the first
 	 * thing matched by this parser be an element returned by
-	 * {@link #addAllLeadingKeywordsTo(Set)} ?
+	 * {@link #addAllLeadingKeywordsTo(Set, Set)} ?
 	 * <p>
 	 * By default this returns <code>false</code>, disabling lookahead for this
 	 * parser, thereby defaulting to the old behaviour.

--- a/src/core/koopa/core/parsers/Stack.java
+++ b/src/core/koopa/core/parsers/Stack.java
@@ -191,7 +191,7 @@ public class Stack {
 				return Collections.emptySet();
 
 			Set<String> keywords = new HashSet<>();
-			parser.addAllKeywordsInScopeTo(keywords);
+			parser.addAllKeywordsInScopeTo(keywords, new HashSet<>());
 			return keywords;
 		}
 

--- a/src/core/koopa/core/parsers/combinators/At.java
+++ b/src/core/koopa/core/parsers/combinators/At.java
@@ -39,7 +39,7 @@ public class At extends UnaryParserDecorator {
 	 * not contribute any keywords.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
@@ -47,7 +47,7 @@ public class At extends UnaryParserDecorator {
 	 * not contribute any keywords.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**

--- a/src/core/koopa/core/parsers/combinators/FailMatch.java
+++ b/src/core/koopa/core/parsers/combinators/FailMatch.java
@@ -35,14 +35,14 @@ public class FailMatch extends ParserCombinator {
 	 * This parser always fails, and so does not contribute any keywords.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
 	 * This parser always fails, and so does not contribute any keywords.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**

--- a/src/core/koopa/core/parsers/combinators/MatchTree.java
+++ b/src/core/koopa/core/parsers/combinators/MatchTree.java
@@ -107,14 +107,14 @@ public class MatchTree extends UnaryParserDecorator {
 	 * This parser ..., and so does not contribute any keywords.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
 	 * This parser ..., and so does not contribute any keywords.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**

--- a/src/core/koopa/core/parsers/combinators/NAryParserDecorator.java
+++ b/src/core/koopa/core/parsers/combinators/NAryParserDecorator.java
@@ -20,18 +20,18 @@ public abstract class NAryParserDecorator extends ParserCombinator {
 	 * Will pass the message on to all {@link #parsers}.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (ParserCombinator parser : parsers)
-			parser.addAllKeywordsInScopeTo(keywords);
+			parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	/**
 	 * Will pass the message on to all {@link #parsers}.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (ParserCombinator parser : parsers)
-			parser.addAllLeadingKeywordsTo(keywords);
+			parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	/**

--- a/src/core/koopa/core/parsers/combinators/Not.java
+++ b/src/core/koopa/core/parsers/combinators/Not.java
@@ -40,7 +40,7 @@ public class Not extends UnaryParserDecorator {
 	 * not contribute any keywords.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**
@@ -48,7 +48,7 @@ public class Not extends UnaryParserDecorator {
 	 * not contribute any keywords.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	/**

--- a/src/core/koopa/core/parsers/combinators/Sequence.java
+++ b/src/core/koopa/core/parsers/combinators/Sequence.java
@@ -27,15 +27,15 @@ public class Sequence extends ParserCombinator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (ParserCombinator parser : parsers)
-			parser.addAllKeywordsInScopeTo(keywords);
+			parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 		for (int i = 0; i < length; i++) {
-			parsers[i].addAllLeadingKeywordsTo(keywords);
+			parsers[i].addAllLeadingKeywordsTo(keywords, scopesSeen);
 			if (!parsers[i].canMatchEmptyInputs())
 				break;
 		}

--- a/src/core/koopa/core/parsers/combinators/SkipTo.java
+++ b/src/core/koopa/core/parsers/combinators/SkipTo.java
@@ -76,11 +76,11 @@ public class SkipTo extends UnaryParserDecorator {
 	}
 
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
 	}
 
 	@Override

--- a/src/core/koopa/core/parsers/combinators/UnaryParserDecorator.java
+++ b/src/core/koopa/core/parsers/combinators/UnaryParserDecorator.java
@@ -20,16 +20,16 @@ public abstract class UnaryParserDecorator extends ParserCombinator {
 	 * Will pass the message on to {@link #parser}.
 	 */
 	@Override
-	public void addAllKeywordsInScopeTo(Set<String> keywords) {
-		parser.addAllKeywordsInScopeTo(keywords);
+	public void addAllKeywordsInScopeTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllKeywordsInScopeTo(keywords, scopesSeen);
 	}
 
 	/**
 	 * Will pass the message on to {@link #parser}.
 	 */
 	@Override
-	public void addAllLeadingKeywordsTo(Set<String> keywords) {
-		parser.addAllLeadingKeywordsTo(keywords);
+	public void addAllLeadingKeywordsTo(Set<String> keywords, Set<String> scopesSeen) {
+		parser.addAllLeadingKeywordsTo(keywords, scopesSeen);
 	}
 
 	/**


### PR DESCRIPTION
Prevent recursion by tracking which scopes have already been evaluated, and therefore can make no additional contributions to the set of keywords.