### PR TITLE
Make test files independent from local character encoding (fixes #53)

### DIFF
--- a/test/cobol/koopa/cobol/parser/preprocessing/test/PreprocessingSourceTest.java
+++ b/test/cobol/koopa/cobol/parser/preprocessing/test/PreprocessingSourceTest.java
@@ -1,5 +1,7 @@
 package koopa.cobol.parser.preprocessing.test;
 
+import static koopa.core.util.test.Util.getCharset;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -74,7 +76,7 @@ public class PreprocessingSourceTest implements FileBasedTest {
 		private StringBuilder expected = new StringBuilder();
 
 		public Sample(File file) throws IOException {
-			BufferedReader br = new BufferedReader(new FileReader(file));
+			BufferedReader br = new BufferedReader(new FileReader(file, getCharset()));
 			try {
 				String line = null;
 				while ((line = br.readLine()) != null) {

--- a/test/cobol/koopa/cobol/parser/preprocessing/test/PreprocessingSourceTest.java
+++ b/test/cobol/koopa/cobol/parser/preprocessing/test/PreprocessingSourceTest.java
@@ -1,6 +1,6 @@
 package koopa.cobol.parser.preprocessing.test;
 
-import static koopa.core.util.test.Util.getCharset;
+import static koopa.core.util.test.Util.testFilesCharset;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -8,6 +8,11 @@ import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.Charset;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import koopa.cobol.CobolTokens;
 import koopa.cobol.projects.StandardCobolProject;
@@ -18,13 +23,11 @@ import koopa.core.sources.Source;
 import koopa.core.util.test.FileBasedTest;
 import koopa.core.util.test.Files;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 @RunWith(Files.class)
 public class PreprocessingSourceTest implements FileBasedTest {
 
+	private static final Charset TEST_FILES_CHARSET = testFilesCharset();
+	
 	private static final String INPUT_PREFIX = "<";
 	private static final String EXPECTED_PREFIX = ">";
 	private static final String LINE_SEPARATOR = System.lineSeparator();
@@ -76,7 +79,7 @@ public class PreprocessingSourceTest implements FileBasedTest {
 		private StringBuilder expected = new StringBuilder();
 
 		public Sample(File file) throws IOException {
-			BufferedReader br = new BufferedReader(new FileReader(file, getCharset()));
+			BufferedReader br = new BufferedReader(new FileReader(file, TEST_FILES_CHARSET));
 			try {
 				String line = null;
 				while ((line = br.readLine()) != null) {

--- a/test/cobol/koopa/cobol/parser/test/TestResult.java
+++ b/test/cobol/koopa/cobol/parser/test/TestResult.java
@@ -1,5 +1,7 @@
 package koopa.cobol.parser.test;
 
+import static koopa.core.util.test.Util.getCharset;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
@@ -248,7 +250,7 @@ public class TestResult {
 			throws IOException {
 		CSVReader reader = null;
 		try {
-			reader = new CSVReader(new FileReader(expectedFile));
+			reader = new CSVReader(new FileReader(expectedFile, getCharset()));
 
 			// CSV Header.
 			String[] header = null;

--- a/test/cobol/koopa/cobol/parser/test/TestResult.java
+++ b/test/cobol/koopa/cobol/parser/test/TestResult.java
@@ -1,12 +1,13 @@
 package koopa.cobol.parser.test;
 
-import static koopa.core.util.test.Util.getCharset;
+import static koopa.core.util.test.Util.testFilesCharset;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +28,8 @@ import koopa.core.util.Files;
 
 public class TestResult {
 
+	private static final Charset TEST_FILES_CHARSET = testFilesCharset();
+	
 	/**
 	 * Just a quick override, useful when working on the sources.
 	 */
@@ -250,7 +253,7 @@ public class TestResult {
 			throws IOException {
 		CSVReader reader = null;
 		try {
-			reader = new CSVReader(new FileReader(expectedFile, getCharset()));
+			reader = new CSVReader(new FileReader(expectedFile, TEST_FILES_CHARSET));
 
 			// CSV Header.
 			String[] header = null;

--- a/test/core/koopa/core/sources/test/samples/Sample.java
+++ b/test/core/koopa/core/sources/test/samples/Sample.java
@@ -1,10 +1,10 @@
 package koopa.core.sources.test.samples;
 
+import static koopa.core.util.test.Util.testFilesCharset;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-
-import static koopa.core.util.test.Util.getCharset;
 
 import java.io.File;
 import java.io.FileReader;
@@ -12,6 +12,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -27,6 +28,8 @@ import koopa.core.util.FilenameFilters;
 
 public class Sample {
 
+	private static final Charset TEST_FILES_CHARSET = testFilesCharset();
+	
 	private final String input;
 	private final List<Range> ranges;
 	private final List<Annotation> annotations;
@@ -55,7 +58,7 @@ public class Sample {
 	private static List<Block> allBlocksFrom(File file) throws IOException {
 		FileReader fileReader = null;
 		try {
-			fileReader = new FileReader(file, getCharset());
+			fileReader = new FileReader(file, TEST_FILES_CHARSET);
 
 			final Source source = new LineSplitter(fileReader);
 			final List<Block> blocks = new ArrayList<>();

--- a/test/core/koopa/core/sources/test/samples/Sample.java
+++ b/test/core/koopa/core/sources/test/samples/Sample.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static koopa.core.util.test.Util.getCharset;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.FilenameFilter;
@@ -53,7 +55,7 @@ public class Sample {
 	private static List<Block> allBlocksFrom(File file) throws IOException {
 		FileReader fileReader = null;
 		try {
-			fileReader = new FileReader(file);
+			fileReader = new FileReader(file, getCharset());
 
 			final Source source = new LineSplitter(fileReader);
 			final List<Block> blocks = new ArrayList<>();

--- a/test/core/koopa/core/util/test/Util.java
+++ b/test/core/koopa/core/util/test/Util.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-
 import koopa.core.data.Data;
 import koopa.core.data.Position;
 import koopa.core.data.Range;
@@ -23,35 +21,10 @@ import koopa.core.trees.Tree;
 
 public final class Util {
 
-	private static final Logger LOGGER = Logger.getLogger("source.test");
-	
-	private static Charset charset;
-	static {
-		final String encoding = System.getProperty("koopa.test.encoding");
+	private static final Charset TEST_FILES_CHARSET = StandardCharsets.UTF_8;
 
-		if (encoding == null) {
-			charset = StandardCharsets.UTF_8;
-
-			if (LOGGER.isTraceEnabled())
-				LOGGER.trace("System property koopa.test.encoding not set, using default test charset: " + charset + ".");
-
-		} else if (!Charset.isSupported(encoding)) {
-			charset = StandardCharsets.UTF_8;
-
-			if (LOGGER.isTraceEnabled())
-				LOGGER.trace("Encoding not supported: '" + encoding
-						+ "'. Using default test charset instead: " + charset + ".");
-
-		} else {
-			charset = Charset.forName(encoding);
-
-			if (LOGGER.isTraceEnabled())
-				LOGGER.trace("Using specified charset: " + charset + ".");
-		}
-	}
-
-	public static Charset getCharset() {
-		return charset;
+	public static Charset testFilesCharset() {
+		return TEST_FILES_CHARSET;
 	}
 	
 	public static List<Range> asListOfRanges(int... positions) {

--- a/test/core/koopa/core/util/test/Util.java
+++ b/test/core/koopa/core/util/test/Util.java
@@ -2,9 +2,13 @@ package koopa.core.util.test;
 
 import static koopa.core.data.tags.AreaTag.PROGRAM_TEXT_AREA;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.apache.log4j.Logger;
 
 import koopa.core.data.Data;
 import koopa.core.data.Position;
@@ -18,6 +22,38 @@ import koopa.core.sources.test.HardcodedSource;
 import koopa.core.trees.Tree;
 
 public final class Util {
+
+	private static final Logger LOGGER = Logger.getLogger("source.test");
+	
+	private static Charset charset;
+	static {
+		final String encoding = System.getProperty("koopa.test.encoding");
+
+		if (encoding == null) {
+			charset = StandardCharsets.UTF_8;
+
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("System property koopa.test.encoding not set, using default test charset: " + charset + ".");
+
+		} else if (!Charset.isSupported(encoding)) {
+			charset = StandardCharsets.UTF_8;
+
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("Encoding not supported: '" + encoding
+						+ "'. Using default test charset instead: " + charset + ".");
+
+		} else {
+			charset = Charset.forName(encoding);
+
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("Using specified charset: " + charset + ".");
+		}
+	}
+
+	public static Charset getCharset() {
+		return charset;
+	}
+	
 	public static List<Range> asListOfRanges(int... positions) {
 		List<Range> ranges = new ArrayList<>();
 


### PR DESCRIPTION
Assume test files (.sample) are encoded as per system property koopa.test.encoding or, if not set, default to UTF-8. Fixes #53.