### PR TITLE
Fixes broken "Show grammar..." functionality in Koopa GUI application (fixes #55).

### DIFF
--- a/src/apps/koopa/app/components/grammarview/GrammarView.java
+++ b/src/apps/koopa/app/components/grammarview/GrammarView.java
@@ -302,7 +302,7 @@ public class GrammarView extends JPanel {
 				if (style == null)
 					style = getDefaultStyle(document);
 
-				document.insertString(token.getStart().getPositionInFile(),
+				document.insertString(token.getStart().getPositionInFile() - 1,
 						token.getText(), style);
 			}
 		} catch (BadLocationException e) {


### PR DESCRIPTION
Trivial fix to `koopa.app.components.grammarview.GrammarView::colorize` to accomodate for differences between Koopa source position (1-based) and Swing document position (0-based). Fixes #55.