### PR TITLE
Simplify Ant build script leveraging the --release javac parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,11 @@ Complex XPath query results should be presented in serialized form.
 
 ### Java 11
 
-The minimum target runtime environment for Koopa is Java 11. To that end the build script forces everything to be compiled to Java 11 compatible bytecode. This, however, is not enough to ensure Java 11 compatibility as you may still be compiling against the library of a later Java version. For that reason you also need to specify where the Java 11 runtime library can be found, by setting the `JAVA11_BOOTCLASSES` environment variable to its location.
+The minimum target runtime environment for Koopa is Java 11. To that end the build script forces everything to be compiled to Java 11 compatible bytecode. If your JDK is not able to compile to Java 11 bytecode (class file version 55), the build will fail with the following message:
 
-You may see following message when building the project with ANT:
+    "Java 11+ is required, but current version is x.y".
 
-    Please make sure JAVA11_BOOTCLASSES is set to a valid Java 11 bootstrap classpath.
-    You may get builds which are not compatible with Java 11 otherwise.
-
-This is a reminder from the build script that you have not specified where the Java 11 runtime library may be found.
+Please launch the Ant build with a JDK 11+.
 
 ### Parser Generation
 

--- a/build.xml
+++ b/build.xml
@@ -3,13 +3,7 @@
 
 	<property name="koopa.java.version" value="11" />
 
-	<!-- Thank you: http://stackoverflow.com/questions/7260697/set-ant-bootclasspath-jdk-1-7-has-a-new-javac-warning-for-setting-an-older-sour -->
 	<property environment="env" />
-	<property name="koopa.java.boot.classpath" value="${env.JAVA11_BOOTCLASSES}" />
-	<echo unless:set="env.JAVA11_BOOTCLASSES">
-        Please make sure JAVA11_BOOTCLASSES is set to a valid Java ${koopa.java.version} bootstrap classpath.
-        You may get builds which are not compatible with Java ${koopa.java.version} otherwise.
-    </echo>
 
     <condition property="koopa.revision" value="${env.KOOPA_REVISION}" else="unknown">
         <isset property="env.KOOPA_REVISION" />
@@ -41,7 +35,8 @@
 
 	<target name="core-compile" depends="core-build,revision-number">
 		<echo>Compiling Koopa's core...</echo>
-		<javac srcdir="src/core/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/core/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="lib">
 					<include name="*.jar" />
@@ -59,7 +54,8 @@
 
 	<target name="core-tests" depends="core">
 		<echo>Compiling unit tests...</echo>
-		<javac srcdir="test/core/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="test/core/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -125,7 +121,8 @@
 
 	<target name="templates">
 		<echo>Compiling Koopa Templates DSL...</echo>
-		<javac srcdir="src/templates/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/templates/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -139,7 +136,8 @@
 
 	<target name="dsl" depends="core,templates">
 		<echo>Compiling Koopa Grammar DSL...</echo>
-		<javac srcdir="src/dsl/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/dsl/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -158,7 +156,8 @@
 
 	<target name="dsl-tests" depends="core,core-tests,dsl">
 		<echo>Compiling unit tests...</echo>
-		<javac srcdir="test/dsl/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="test/dsl/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -200,7 +199,8 @@
 		<kgg path="src/cics/" />
 
 		<echo>Compiling parsers...</echo>
-		<javac srcdir="src/cics/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/cics/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -219,7 +219,8 @@
 
 	<target name="cics-tests" depends="core,core-tests,cics">
 		<echo>Compiling unit tests...</echo>
-		<javac srcdir="test/cics/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="test/cics/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -260,7 +261,8 @@
 		<kgg path="src/sql/" />
 
 		<echo>Compiling parsers...</echo>
-		<javac srcdir="src/sql/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/sql/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -279,7 +281,8 @@
 
 	<target name="sql-tests" depends="core,core-tests,sql">
 		<echo>Compiling unit tests...</echo>
-		<javac srcdir="test/sql/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="test/sql/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -320,7 +323,8 @@
 		<kgg path="src/cobol/" />
 
 		<echo>Compiling parsers...</echo>
-		<javac srcdir="src/cobol/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/cobol/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -339,7 +343,8 @@
 
 	<target name="cobol-tests" depends="core,core-tests,cobol">
 		<echo>Compiling unit tests...</echo>
-		<javac srcdir="test/cobol/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="test/cobol/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="build/" />
 				<fileset dir="lib">
@@ -430,7 +435,8 @@
 		<kgg path="src/apps/" />
 
 		<echo>Compiling processing classes...</echo>
-		<javac srcdir="src/apps/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="src/apps/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="lib">
 					<include name="*.jar" />
@@ -451,14 +457,15 @@
 		<kgg path="examples/" />
 
 		<echo>Compiling example classes...</echo>
-		<javac srcdir="examples/basic/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<requires-java min="${koopa.java.version}" />
+		<javac srcdir="examples/basic/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="lib">
 					<include name="*.jar" />
 				</fileset>
 			</classpath>
 		</javac>
-		<javac srcdir="examples/jaxen/" destdir="build/" debug="on" source="${koopa.java.version}" target="${koopa.java.version}" bootclasspath="${koopa.java.boot.classpath}" includeantruntime="false">
+		<javac srcdir="examples/jaxen/" destdir="build/" debug="on" release="${koopa.java.version}" includeantruntime="false">
 			<classpath>
 				<fileset dir="lib">
 					<include name="*.jar" />
@@ -583,4 +590,16 @@
 			</java>
 		</sequential>
 	</macrodef>
+	
+	<macrodef name="requires-java">
+		<attribute name="min"/>
+		<sequential>
+			<condition property="java.version.ok">
+				<javaversion atleast="@{min}"/>
+			</condition>
+			<fail unless="java.version.ok"
+				  message="Java @{min}+ is required, but current version is ${java.version}"/>
+		</sequential>
+	</macrodef>
+
 </project>

--- a/src/core/koopa/core/util/ClassVersionChecker.java
+++ b/src/core/koopa/core/util/ClassVersionChecker.java
@@ -2,8 +2,6 @@ package koopa.core.util;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This class reports its own class version, which helps me verify that things
@@ -14,41 +12,46 @@ import java.util.Map;
  * So with this I can now double check easily what version of Java the compiled
  * result is targeted at.
  */
-public class ClassVersionChecker {
-	public static final Map<String, String> JAVA_VERSIONS = new HashMap<>();
+public final class ClassVersionChecker {
 
-	static {
-		JAVA_VERSIONS.put("45.3", "1.0");
-		JAVA_VERSIONS.put("45.3", "1.1");
-		JAVA_VERSIONS.put("46.0", "1.2");
-		JAVA_VERSIONS.put("47.0", "1.3");
-		JAVA_VERSIONS.put("48.0", "1.4");
-		JAVA_VERSIONS.put("49.0", "1.5");
-		JAVA_VERSIONS.put("50.0", "1.6");
-		JAVA_VERSIONS.put("51.0", "1.7");
-		JAVA_VERSIONS.put("52.0", "1.8");
+	private ClassVersionChecker() {
 	}
+
+	// TODO: when on JDK 20+ see java.lang.reflect.ClassFileFormatVersion
+
+	// Java 1.0, has major version 45 like Java 1.1
+	private static final int FILE_VERSION_O = 45;
+
+	// Java 28, https://docs.oracle.com/en/java/javase/28/docs/specs/jvms/index.html
+	private static final int FILE_VERSION_LATEST = 72; 
+
+	public static final String[] JAVA_VERSIONS = { "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "9", "10",
+			"11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27",
+			"28" };
 
 	public static void main(String[] args) throws IOException {
-		DataInputStream in = new DataInputStream(
-				ClassVersionChecker.class
-						.getResourceAsStream("ClassVersionChecker.class"));
 
-		final int magicNumber = in.readInt();
-		if (magicNumber != 0xcafebabe)
-			System.out.println("Not a valid class!");
+		try (final DataInputStream in = new DataInputStream(
+				ClassVersionChecker.class.getResourceAsStream("ClassVersionChecker.class"))){
 
-		final int minorVersion = in.readUnsignedShort();
-		final int majorVersion = in.readUnsignedShort();
-		final String version = majorVersion + "." + minorVersion;
+			final int magicNumber = in.readInt();
+			if (magicNumber != 0xcafebabe) {
+				System.out.println("Not a valid class file!");
+				System.exit(1);
+			}
 
-		if (JAVA_VERSIONS.containsKey(version))
-			System.out.println("Version " + version + " (Java "
-					+ JAVA_VERSIONS.get(version) + ")");
-		else
-			System.out
-					.println("Version " + version + " (unknown Java version)");
+			final int minorFileVersion = in.readUnsignedShort();
+			final int majorFileVersion = in.readUnsignedShort();
+			final String fileVersion = majorFileVersion + "." + minorFileVersion;
 
-		in.close();
+			if (45 <= majorFileVersion || FILE_VERSION_LATEST <= majorFileVersion) {
+				System.out.println(
+						"Generated class file version " + fileVersion + " (Java " + JAVA_VERSIONS[majorFileVersion - FILE_VERSION_O] + ")");
+			} else {
+				System.out.println("Generated class file version " + fileVersion + " (unknown Java version)");
+			}
+		}
+
 	}
+
 }


### PR DESCRIPTION
Now that the minimum required Java version is >= 9, the Ant build script can be simplified levaraging the --release javac parameter and getting rid of the environment variable previously used to set bootclasspath.