### PR TITLE
Add .gitattributes to prevent accidental binary file corruption

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.jar binary
+*.pdf binary
+*.png binary


### PR DESCRIPTION
Create .gitattributes file and add binary attribute for jar, pdf, and png files. See #60.