### PR TITLE
CobolOutlineTreeProcessor not showing the full tree (fixes #63)

### DIFF
--- a/src/apps/koopa/app/components/outline/CobolOutlineTreeProcessor.java
+++ b/src/apps/koopa/app/components/outline/CobolOutlineTreeProcessor.java
@@ -46,7 +46,7 @@ public class CobolOutlineTreeProcessor {
 
 			} else if (tree.isNode("sourceUnit")) {
 				w.skipRemainderOfTree(tree);
-				final String name = Jaxen.getAllText(tree, ".//programName");
+				final String name = Jaxen.getAllText(tree, ".//programIdParagraph/programName");
 				push(new Reference(tree, name, PROGRAM_ICON));
 				walk(tree);
 				pop();


### PR DESCRIPTION
The CobolOutlineTreeProcessor is not showing the full tree if the source unit contains more than a rule that recall "programName" as a subrule. It is easily fixed making the xpath query more restrictive. Fixes #63.