### PR TITLE
Enable Show Grammar Rule also on odd rules (fixes #68)

### DIFF
--- a/src/apps/koopa/app/components/detail/token/ListOfGrammarRules.java
+++ b/src/apps/koopa/app/components/detail/token/ListOfGrammarRules.java
@@ -110,14 +110,11 @@ public class ListOfGrammarRules extends JPanel implements
 
 		} else {
 			label = new JLabel(crumb);
-			labels.add(label);
-
 			label.setFont(FONT);
+			label.setCursor(new Cursor(Cursor.HAND_CURSOR));
+			label.addMouseListener(mouseClickListener);
 
-			if (index % 2 == 0) {
-				label.setCursor(new Cursor(Cursor.HAND_CURSOR));
-				label.addMouseListener(mouseClickListener);
-			}
+			labels.add(label);
 		}
 
 		index += 1;


### PR DESCRIPTION
ListOfGrammarRules::getLabel inexplicably sets cursor and mouse listener only on items with even index. Fixes #68.