### PR TITLE
Better compliance with Iterator's contract and unnecessary overriding of remove method (was "Decluttering of KoopaNavigator")

### DIFF
--- a/src/core/koopa/core/trees/iterators/ChildDataIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildDataIterator.java
@@ -30,8 +30,4 @@ public class ChildDataIterator implements Iterator<Data> {
 		return data;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/iterators/ChildDataIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildDataIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.iterators;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.data.Data;
 import koopa.core.trees.Tree;
@@ -25,6 +26,9 @@ public class ChildDataIterator implements Iterator<Data> {
 
 	@Override
 	public Data next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		Data data = root.getChild(index).getData();
 		index += 1;
 		return data;

--- a/src/core/koopa/core/trees/iterators/ChildTokenIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildTokenIterator.java
@@ -53,8 +53,4 @@ public class ChildTokenIterator implements Iterator<Token> {
 			index += 1;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/iterators/ChildTokenIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildTokenIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.iterators;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.data.Token;
 import koopa.core.trees.TokenFilter;
@@ -35,6 +36,9 @@ public class ChildTokenIterator implements Iterator<Token> {
 
 	@Override
 	public Token next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		Token next = (Token) root.getChild(index).getData();
 		moveToNextMatchingToken();
 		return next;

--- a/src/core/koopa/core/trees/iterators/ChildTreeIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildTreeIterator.java
@@ -38,8 +38,4 @@ public class ChildTreeIterator implements Iterator<Tree> {
 			index += 1;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/iterators/ChildTreeIterator.java
+++ b/src/core/koopa/core/trees/iterators/ChildTreeIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.iterators;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.trees.Tree;
 
@@ -27,6 +28,9 @@ public class ChildTreeIterator implements Iterator<Tree> {
 
 	@Override
 	public Tree next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		Tree next = root.getChild(index);
 		moveToNextNode();
 		return next;

--- a/src/core/koopa/core/trees/iterators/DepthFirstTokenIterator.java
+++ b/src/core/koopa/core/trees/iterators/DepthFirstTokenIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.iterators;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.data.Token;
 import koopa.core.trees.TokenFilter;
@@ -37,6 +38,9 @@ public class DepthFirstTokenIterator implements Iterator<Token> {
 
 	@Override
 	public Token next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		Token next = (Token) current.getData();
 		moveToNextMatchingToken();
 		return next;

--- a/src/core/koopa/core/trees/iterators/DepthFirstTokenIterator.java
+++ b/src/core/koopa/core/trees/iterators/DepthFirstTokenIterator.java
@@ -99,8 +99,4 @@ public class DepthFirstTokenIterator implements Iterator<Token> {
 		}
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/AttributeAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/AttributeAxisIterator.java
@@ -3,6 +3,7 @@ package koopa.core.trees.jaxen;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import koopa.core.data.Data;
@@ -48,6 +49,9 @@ public class AttributeAxisIterator implements Iterator<TreeAttribute> {
 
 	@Override
 	public TreeAttribute next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		return this.attributes.get(this.index++);
 	}
 

--- a/src/core/koopa/core/trees/jaxen/AttributeAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/AttributeAxisIterator.java
@@ -51,8 +51,4 @@ public class AttributeAxisIterator implements Iterator<TreeAttribute> {
 		return this.attributes.get(this.index++);
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/ChildAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/ChildAxisIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.jaxen;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,6 +38,9 @@ public class ChildAxisIterator implements Iterator<Tree> {
 	public Tree next() {
 		if (LOGGER.isTraceEnabled())
 			LOGGER.trace("ChildAxisIterator(" + parent + ").next()");
+
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
 
 		final Tree next = this.parent.getChild(this.index++);
 

--- a/src/core/koopa/core/trees/jaxen/ChildAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/ChildAxisIterator.java
@@ -46,8 +46,4 @@ public class ChildAxisIterator implements Iterator<Tree> {
 		return next;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/DescendantOrSelfAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/DescendantOrSelfAxisIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.jaxen;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.trees.Tree;
 
@@ -21,6 +22,9 @@ public class DescendantOrSelfAxisIterator implements Iterator<Tree> {
 
 	@Override
 	public Tree next() {
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
+
 		final Tree tree = this.next;
 
 		moveOn();

--- a/src/core/koopa/core/trees/jaxen/DescendantOrSelfAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/DescendantOrSelfAxisIterator.java
@@ -61,8 +61,4 @@ public class DescendantOrSelfAxisIterator implements Iterator<Tree> {
 		}
 	}
 
-	@Override
-	public void remove() {
-		new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/FollowingSibilingAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/FollowingSibilingAxisIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.jaxen;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import koopa.core.trees.Tree;
 
@@ -37,6 +38,9 @@ public class FollowingSibilingAxisIterator implements Iterator<Tree> {
 	public Tree next() {
 		if (LOGGER.isTraceEnabled())
 			LOGGER.trace("FollowingSibilingAxisIterator(" + parent + ").next()");
+
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
 
 		final Tree next;
 		if (index < parent.getChildCount())

--- a/src/core/koopa/core/trees/jaxen/FollowingSibilingAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/FollowingSibilingAxisIterator.java
@@ -50,8 +50,4 @@ public class FollowingSibilingAxisIterator implements Iterator<Tree> {
 		return next;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/ParentAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/ParentAxisIterator.java
@@ -45,8 +45,4 @@ public class ParentAxisIterator implements Iterator<Tree> {
 		return next;
 	}
 
-	@Override
-	public void remove() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/core/koopa/core/trees/jaxen/ParentAxisIterator.java
+++ b/src/core/koopa/core/trees/jaxen/ParentAxisIterator.java
@@ -1,6 +1,7 @@
 package koopa.core.trees.jaxen;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,6 +36,9 @@ public class ParentAxisIterator implements Iterator<Tree> {
 	public Tree next() {
 		if (LOGGER.isTraceEnabled())
 			LOGGER.trace("ParentAxisIterator(" + tree + ").next()");
+
+		if (!hasNext())
+			throw new NoSuchElementException("Called next on an iterator with no more elements");
 
 		final Tree next = tree.getParent();
 		seen = true;


### PR DESCRIPTION
Better compliance with `Iterator`'s contract and unnecessary overriding of `remove` method (was "Decluttering of KoopaNavigator in preparation for further refactoring").