### PR TITLE
Moved TestTokenizer and HardcodedSource for better segregation of test classes.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,16 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/core"/>
-	<classpathentry kind="src" path="test/core"/>
+	<classpathentry kind="src" output="koopa/build/test" path="test/core">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/templates"/>
 	<classpathentry kind="src" path="src/dsl"/>
-	<classpathentry kind="src" path="test/dsl"/>
+	<classpathentry kind="src" output="koopa/build/test" path="test/dsl">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/cics"/>
-	<classpathentry kind="src" path="test/cics"/>
+	<classpathentry kind="src" output="koopa/build/test" path="test/cics">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/sql"/>
-	<classpathentry kind="src" path="test/sql"/>
+	<classpathentry kind="src" output="koopa/build/test" path="test/sql">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/cobol"/>
-	<classpathentry kind="src" path="test/cobol"/>
+	<classpathentry kind="src" output="koopa/build/test" path="test/cobol">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/apps"/>
 	<classpathentry kind="src" path="examples/jaxen"/>
 	<classpathentry kind="src" path="examples/basic"/>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/core/koopa/core/sources/HardcodedSource.java
+++ b/src/core/koopa/core/sources/HardcodedSource.java
@@ -1,4 +1,4 @@
-package koopa.core.sources.test;
+package koopa.core.sources;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -7,8 +7,6 @@ import java.util.List;
 import koopa.core.data.Data;
 import koopa.core.data.Position;
 import koopa.core.data.Token;
-import koopa.core.sources.BasicSource;
-import koopa.core.sources.Source;
 
 /**
  * Simple source of tokens which accepts a list of strings and tags, and returns

--- a/src/core/koopa/core/sources/TestTokenizer.java
+++ b/src/core/koopa/core/sources/TestTokenizer.java
@@ -1,4 +1,4 @@
-package koopa.core.sources.test;
+package koopa.core.sources;
 
 import java.util.LinkedList;
 
@@ -8,8 +8,6 @@ import org.apache.logging.log4j.Logger;
 import koopa.core.data.Data;
 import koopa.core.data.Token;
 import koopa.core.data.tags.AreaTag;
-import koopa.core.sources.ChainingSource;
-import koopa.core.sources.Source;
 
 /**
  * A {@linkplain Source} which can tell you whether or not it has reached an

--- a/src/dsl/koopa/dsl/stage/runtime/GrammarTestSuite.java
+++ b/src/dsl/koopa/dsl/stage/runtime/GrammarTestSuite.java
@@ -24,7 +24,7 @@ import koopa.core.grammars.Grammar;
 import koopa.core.parsers.Parse;
 import koopa.core.parsers.ParserCombinator;
 import koopa.core.sources.Source;
-import koopa.core.sources.test.TestTokenizer;
+import koopa.core.sources.TestTokenizer;
 import koopa.core.targets.ListTarget;
 import koopa.core.util.Files;
 import koopa.core.util.Reflect;

--- a/src/dsl/koopa/dsl/stage/runtime/generation/Mark.java
+++ b/src/dsl/koopa/dsl/stage/runtime/generation/Mark.java
@@ -2,7 +2,7 @@ package koopa.dsl.stage.runtime.generation;
 
 import java.util.LinkedList;
 
-import koopa.core.sources.test.TestTokenizer;
+import koopa.core.sources.TestTokenizer;
 
 /**
  * This marks a point in the grammar unit test where we expect the parser to end

--- a/test/cobol/koopa/cobol/parser/preprocessing/replacing/test/ReplacingPhraseOperandTest.java
+++ b/test/cobol/koopa/cobol/parser/preprocessing/replacing/test/ReplacingPhraseOperandTest.java
@@ -28,9 +28,9 @@ import koopa.cobol.parser.preprocessing.replacing.ReplacingPhraseOperand;
 import koopa.core.data.Data;
 import koopa.core.data.Position;
 import koopa.core.data.Token;
+import koopa.core.sources.HardcodedSource;
 import koopa.core.sources.Source;
 import koopa.core.sources.TagAll;
-import koopa.core.sources.test.HardcodedSource;
 
 public class ReplacingPhraseOperandTest {
 

--- a/test/core/koopa/core/grammars/test/GrammarTest.java
+++ b/test/core/koopa/core/grammars/test/GrammarTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import koopa.core.grammars.combinators.Scoped;
 import koopa.core.parsers.Parse;
 import koopa.core.parsers.ParserCombinator;
-import koopa.core.sources.test.HardcodedSource;
+import koopa.core.sources.HardcodedSource;
 import koopa.core.targets.ListTarget;
 import koopa.core.trees.KoopaTreeBuilder;
 import koopa.core.trees.Tree;

--- a/test/core/koopa/core/sources/test/TestTokenizerTest.java
+++ b/test/core/koopa/core/sources/test/TestTokenizerTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import koopa.core.data.Data;
 import koopa.core.data.Token;
+import koopa.core.sources.HardcodedSource;
+import koopa.core.sources.TestTokenizer;
 
 public class TestTokenizerTest {
 

--- a/test/core/koopa/core/streams/test/BaseStreamTest.java
+++ b/test/core/koopa/core/streams/test/BaseStreamTest.java
@@ -3,7 +3,7 @@ package koopa.core.streams.test;
 import org.junit.jupiter.api.Test;
 
 import koopa.core.parsers.Stream;
-import koopa.core.sources.test.HardcodedSource;
+import koopa.core.sources.HardcodedSource;
 import koopa.core.streams.BaseStream;
 import koopa.core.targets.ListTarget;
 

--- a/test/core/koopa/core/streams/test/LimitedStreamTest.java
+++ b/test/core/koopa/core/streams/test/LimitedStreamTest.java
@@ -6,7 +6,7 @@ import koopa.core.data.Data;
 import koopa.core.data.Token;
 import koopa.core.parsers.Parse;
 import koopa.core.parsers.ParserCombinator;
-import koopa.core.sources.test.HardcodedSource;
+import koopa.core.sources.HardcodedSource;
 import koopa.core.streams.BaseStream;
 import koopa.core.streams.LimitedStream;
 import koopa.core.targets.ListTarget;

--- a/test/core/koopa/core/util/test/Util.java
+++ b/test/core/koopa/core/util/test/Util.java
@@ -14,9 +14,9 @@ import koopa.core.data.Range;
 import koopa.core.data.Token;
 import koopa.core.data.markers.Start;
 import koopa.core.data.tags.AreaTag;
+import koopa.core.sources.HardcodedSource;
 import koopa.core.sources.Source;
 import koopa.core.sources.TagAll;
-import koopa.core.sources.test.HardcodedSource;
 import koopa.core.trees.Tree;
 
 public final class Util {


### PR DESCRIPTION
Moved TestTokenizer and HardcodedSource for better separation of test and runtime classpaths. Modified Eclipse configuration to mark packages under test/ as containing test classes in order to prevent unwanted references from runtime packages to test packages.